### PR TITLE
Use clipboard.write with TSV and HTML formats instead of writeText

### DIFF
--- a/packages/react-core/lib/clipboard.ts
+++ b/packages/react-core/lib/clipboard.ts
@@ -15,9 +15,18 @@ export const clip = (store: StoreType): AreaType => {
   const input = editorRef.current;
   const trimmed = table.trim(area);
   const tsv = table2tsv(trimmed);
+  const html = table2html(trimmed);
 
   if (navigator.clipboard) {
-    navigator.clipboard.writeText(tsv);
+    const tsvBlob = new Blob([tsv], { type: "text/plain" });
+    const htmlBlob = new Blob([html], { type: "text/html" });
+
+    navigator.clipboard.write([
+      new ClipboardItem({
+        "text/plain": tsvBlob,
+        "text/html": htmlBlob
+      })
+    ]);
   } else if (input != null) {
     input.value = tsv;
     input.focus();
@@ -47,4 +56,20 @@ const table2tsv = (table: Table): string => {
     lines.push(cols.join('\t'));
   });
   return lines.join('\n');
+};
+
+const table2html = (table: Table): string => {
+  const lines: string[] = [];
+  const matrix = solveTable({ table, raise: false });
+  matrix.forEach((row, i) => {
+    const y = table.top + i;
+    const cols: string[] = [];
+    row.forEach((col, j) => {
+      const x = table.left + j;
+      const value = table.stringify({ y, x }, col);
+      cols.push(`<td>${ value }</td>`);
+    });
+    lines.push(`<tr>${ cols.join("") }</tr>`);
+  });
+  return lines.join("");
 };

--- a/packages/react-core/lib/clipboard.ts
+++ b/packages/react-core/lib/clipboard.ts
@@ -18,14 +18,14 @@ export const clip = (store: StoreType): AreaType => {
   const html = table2html(trimmed);
 
   if (navigator.clipboard) {
-    const tsvBlob = new Blob([tsv], { type: "text/plain" });
-    const htmlBlob = new Blob([html], { type: "text/html" });
+    const tsvBlob = new Blob([tsv], { type: 'text/plain' });
+    const htmlBlob = new Blob([html], { type: 'text/html' });
 
     navigator.clipboard.write([
       new ClipboardItem({
-        "text/plain": tsvBlob,
-        "text/html": htmlBlob
-      })
+        'text/plain': tsvBlob,
+        'text/html': htmlBlob,
+      }),
     ]);
   } else if (input != null) {
     input.value = tsv;
@@ -67,9 +67,9 @@ const table2html = (table: Table): string => {
     row.forEach((col, j) => {
       const x = table.left + j;
       const value = table.stringify({ y, x }, col);
-      cols.push(`<td>${ value }</td>`);
+      cols.push(`<td>${value}</td>`);
     });
-    lines.push(`<tr>${ cols.join("") }</tr>`);
+    lines.push(`<tr>${cols.join('')}</tr>`);
   });
-  return `<table>${ lines.join("") }</table>`;
+  return `<table>${lines.join('')}</table>`;
 };

--- a/packages/react-core/lib/clipboard.ts
+++ b/packages/react-core/lib/clipboard.ts
@@ -67,7 +67,13 @@ const table2html = (table: Table): string => {
     row.forEach((col, j) => {
       const x = table.left + j;
       const value = table.stringify({ y, x }, col);
-      cols.push(`<td>${value}</td>`);
+      const valueEscaped = value
+        .replaceAll('&', '&amp;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&apos;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;');
+      cols.push(`<td>${valueEscaped}</td>`);
     });
     lines.push(`<tr>${cols.join('')}</tr>`);
   });

--- a/packages/react-core/lib/clipboard.ts
+++ b/packages/react-core/lib/clipboard.ts
@@ -71,5 +71,5 @@ const table2html = (table: Table): string => {
     });
     lines.push(`<tr>${ cols.join("") }</tr>`);
   });
-  return lines.join("");
+  return `<table>${ lines.join("") }</table>`;
 };


### PR DESCRIPTION
### Description

Using only `clipboard.writeText` to copy TSV does not paste correctly into certain spreadsheet software (such as Excel for Mac).
Therefore, by using `clipboard.write` to copy both TSV and HTML formats, we ensure reliable pasting across a wider range of software.

When copying tables, Google Spreadsheet also uses both TSV and HTML formats—similar to this change.

## Type of Change
- [x] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change
- [ ] Reword
- [ ] The other

### Impact Area

There may be potential impact on dependent systems that expect only TSV format.

## How Has This Been Tested?

Tested with Storybook and Excel for Mac (Microsoft 365).

- [x] Visual operation check - `pnpm storybook`
- [x] Test - `pnpm test`
- [x] Lint - `pnpm eslint:fix`

## Additional Context

### Before

<img width="1266" alt="image" src="https://github.com/user-attachments/assets/ed3248d7-a934-45d5-9297-c1a6c2eeae6a" />

### After

<img width="918" alt="スクリーンショット 2025-05-15 13 13 22" src="https://github.com/user-attachments/assets/36cb2351-5d05-4490-bbc5-bec64f518a7f" />
