### PR TITLE
fix: formula rendering in inherited Renderer class

### DIFF
--- a/e2e/basic.spec.ts
+++ b/e2e/basic.spec.ts
@@ -174,4 +174,8 @@ test('rendered cell', async ({ page }) => {
   await a9.click();
   expect(await a9.locator('.gs-cell-rendered').textContent()).toBe('A9');
   expect(await largeEditor.inputValue()).toBe('');
+
+  // fix #97
+  const b10 = page.locator("[data-address='B10']");
+  expect(await b10.locator('.gs-cell-rendered').textContent()).toBe('一〇,八〇〇');
 });

--- a/e2e/formula.spec.ts
+++ b/e2e/formula.spec.ts
@@ -202,3 +202,25 @@ test('insert cols range and rows range by selection in multiple sheets', async (
   await editor2.press('Enter');
   expect(await d4.locator('.gs-cell-rendered').textContent()).toBe('370');
 });
+
+test('disable formula', async ({ page }) => {
+  await page.goto('http://localhost:5233/iframe.html?id=formula--disabled&viewMode=story');
+  const a1 = page.locator("[data-address='A1']");
+  const b1 = page.locator("[data-address='B1']");
+  const a2 = page.locator("[data-address='A2']");
+  const b2 = page.locator("[data-address='B2']");
+  const a3 = page.locator("[data-address='A3']");
+  const b3 = page.locator("[data-address='B3']");
+  const a4 = page.locator("[data-address='A4']");
+  const b4 = page.locator("[data-address='B4']");
+
+  expect(await a1.locator('.gs-cell-rendered').textContent()).toBe('=1+1');
+  expect(await b1.locator('.gs-cell-rendered').textContent()).toBe('2');
+  expect(await a2.locator('.gs-cell-rendered').textContent()).toBe("'quote");
+  expect(await b2.locator('.gs-cell-rendered').textContent()).toBe("quote");
+  expect(await a3.locator('.gs-cell-rendered').textContent()).toBe("'0123");
+  expect(await b3.locator('.gs-cell-rendered').textContent()).toBe('0123');
+  expect(await a4.locator('.gs-cell-rendered').textContent()).toBe('0123');
+  expect(await b4.locator('.gs-cell-rendered').textContent()).toBe('0123');
+
+});

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -7,8 +7,7 @@ test('search and next', async ({ page }) => {
   const progress = page.locator('.gs-search-progress');
   expect(await searchBar.count()).toBe(0);
 
-  await page.keyboard.down('Control');
-  await page.keyboard.press('f');
+  await page.keyboard.press('Control+f');
   await page.waitForSelector('.gs-search-bar', { timeout: 3000 });
 
   expect(await searchBar.count()).toBe(1);

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -2,6 +2,8 @@ import { test, expect } from '@playwright/test';
 
 test('search and next', async ({ page }) => {
   await page.goto('http://localhost:5233/iframe.html?id=basic--large&viewMode=story');
+  const a1 = page.locator("[data-address='A1']");
+  await a1.click();
 
   const searchBar = page.locator('.gs-search-bar');
   const progress = page.locator('.gs-search-progress');

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -9,7 +9,7 @@ test('search and next', async ({ page }) => {
 
   await page.keyboard.down('Control');
   await page.keyboard.press('f');
-  await page.waitForTimeout(500);
+  await page.waitForSelector('.gs-search-bar', { timeout: 3000 });
 
   expect(await searchBar.count()).toBe(1);
   expect(await progress.textContent()).toBe('0 / 0');

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -9,6 +9,7 @@ test('search and next', async ({ page }) => {
 
   await page.keyboard.down('Control');
   await page.keyboard.press('f');
+  await page.waitForTimeout(500);
 
   expect(await searchBar.count()).toBe(1);
   expect(await progress.textContent()).toBe('0 / 0');

--- a/packages/react-core/components/Editor.tsx
+++ b/packages/react-core/components/Editor.tsx
@@ -402,7 +402,7 @@ export const Editor: React.FC<Props> = ({ mode, handleKeyUp }: Props) => {
             width: (editorRef.current?.scrollWidth ?? 0) - 4,
           }}
         >
-          {editorStyle(inputting)}
+          {cell?.disableFormula ? inputting : editorStyle(inputting)}
         </pre>
         <textarea
           autoFocus={true}

--- a/packages/react-core/components/FormulaBar.tsx
+++ b/packages/react-core/components/FormulaBar.tsx
@@ -15,6 +15,7 @@ export const FormulaBar: React.FC = () => {
   const hlRef = React.useRef<HTMLDivElement | null>(null);
 
   const address = choosing.x === -1 ? '' : p2a(choosing);
+  const cell = table.getByPoint(choosing);
   React.useEffect(() => {
     let value = table.getByPoint(choosing)?.value ?? '';
     // debug to remove this line
@@ -79,7 +80,7 @@ export const FormulaBar: React.FC = () => {
             width: largeEditorRef.current?.clientWidth,
           }}
         >
-          {editorStyle(inputting)}
+          {cell?.disableFormula ? inputting : editorStyle(inputting)}
         </div>
         <textarea
           rows={1}

--- a/packages/react-core/lib/clipboard.ts
+++ b/packages/react-core/lib/clipboard.ts
@@ -68,11 +68,11 @@ const table2html = (table: Table): string => {
       const x = table.left + j;
       const value = table.stringify({ y, x }, col);
       const valueEscaped = value
-        .replaceAll('&', '&amp;')
-        .replaceAll('"', '&quot;')
-        .replaceAll("'", '&apos;')
-        .replaceAll('<', '&lt;')
-        .replaceAll('>', '&gt;');
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
       cols.push(`<td>${valueEscaped}</td>`);
     });
     lines.push(`<tr>${cols.join('')}</tr>`);

--- a/packages/react-core/types.ts
+++ b/packages/react-core/types.ts
@@ -49,6 +49,7 @@ export type CellType<Custom = any> = {
   renderer?: string;
   parser?: string;
   custom?: Custom;
+  disableFormula?: boolean;
   prevention?: Prevention;
   changedAt?: Date;
 };

--- a/packages/storybook/stories/basic/renderer.stories.tsx
+++ b/packages/storybook/stories/basic/renderer.stories.tsx
@@ -37,6 +37,9 @@ const NullMixin: RendererMixinType = {
 };
 
 const KanjiRendererMixin: RendererMixinType = {
+  string(value: string): string {
+    return value;
+  },
   number(value: number): string {
     const minus = value < 0;
 
@@ -73,6 +76,9 @@ export const RenderToKanji = () => {
             default: {
               renderer: 'kanji',
             },
+            B10: {
+              value: '=B6+10000',
+            }
           },
           ensured: { numRows: 30, numCols: 20 },
         })}

--- a/packages/storybook/stories/formula/disabled.stories.tsx
+++ b/packages/storybook/stories/formula/disabled.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { constructInitialCells, GridSheet } from '@gridsheet/react-core';
+
+export default {
+  title: 'Formula',
+};
+
+export const Disabled = () => {
+  return (
+    <>
+      <GridSheet
+        initialCells={constructInitialCells({
+          cells: {
+            A: { labeler: 'disabled', width: 150},
+            A1: { value: '=1+1', disableFormula: true },
+            B1: { value: '=1+1' },
+            A2: { value: "'quote", disableFormula: true  },
+            B2: { value: "'quote" },
+            A3: { value: "'0123", disableFormula: true },
+            B3: { value: "'0123" },
+            A4: { value: '0123', disableFormula: true },
+            B4: { value: '0123' },
+            A5: { value: 123, disableFormula: true },
+            B5: { value: 123 },
+          },
+          ensured: { numRows: 5, numCols: 5 },
+        })}
+        options={{
+          labelers: {
+            disabled: (value: string) => {
+              return 'disabled formula';
+            }
+          }
+        }}
+      />
+    </>
+  );
+};


### PR DESCRIPTION
## Description
This change fixes incorrect formula rendering in components that inherit from the Renderer class. (#97)

## Type of Change
- [x] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Breaking change
- [ ] Reword
- [ ] The other

### Impact Area
Renderer.tsx and any component inheriting from Renderer

- Formula rendering logic (e.g., identifying =SUM(...))
- Visual rendering of formula cells
- Possibly impacts formula display consistency across Storybook and production

## How Has This Been Tested?

- [x] Visual operation check - `pnpm storybook`
- [x] Test - `pnpm test`
- [x] Lint - `pnpm eslint:fix`

## Additional Context
To ensure compatibility with older browsers, the HTML escaping logic was rewritten using explicit `.replace()` chains for common special characters. (#99)
