### PR TITLE
Fix/total size

### DIFF
--- a/packages/react-core/src/components/GridSheet.tsx
+++ b/packages/react-core/src/components/GridSheet.tsx
@@ -75,6 +75,7 @@ export function GridSheet({
     table.initialize(initialCells);
     wire.onInit?.({ table });
 
+    table.setTotalSize();
     tableReactive.current = table;
 
     const store: StoreType = {
@@ -112,7 +113,6 @@ export function GridSheet({
       minNumCols: 1,
       maxNumCols: -1,
       mode: 'light',
-      ...table.getTotalSize(),
     };
     return store;
   });
@@ -167,8 +167,8 @@ export function GridSheet({
           ref={mainRef}
           style={{
             //width: '100%',
-            maxWidth: (store.totalWidth || 0) + 2,
-            maxHeight: (store.totalHeight || 0) + 2,
+            maxWidth: (store.tableReactive.current?.totalWidth || 0) + 2,
+            maxHeight: (store.tableReactive.current?.totalHeight || 0) + 2,
             overflow: 'auto',
             resize: sheetResize,
             ...style,

--- a/packages/react-core/src/components/Resizer.tsx
+++ b/packages/react-core/src/components/Resizer.tsx
@@ -70,7 +70,6 @@ export const Resizer = () => {
     dispatch(
       setStore({
         tableReactive: { current: table },
-        ...table.getTotalSize(),
       }),
     );
     dispatch(setResizingPositionY([-1, -1, -1]));

--- a/packages/react-core/src/components/Tabular.tsx
+++ b/packages/react-core/src/components/Tabular.tsx
@@ -30,8 +30,6 @@ export const Tabular = () => {
     inputting,
     leftHeaderSelecting,
     topHeaderSelecting,
-    totalWidth,
-    totalHeight,
   } = store;
   const table = tableReactive.current;
 
@@ -150,8 +148,8 @@ export const Tabular = () => {
         <div
           className={'gs-tabular-inner'}
           style={{
-            width: totalWidth + 1,
-            height: totalHeight + 1,
+            width: table.totalWidth + 1,
+            height: table.totalHeight + 1,
           }}
         >
           <table className={`gs-table`}>

--- a/packages/react-core/src/lib/table.ts
+++ b/packages/react-core/src/lib/table.ts
@@ -419,14 +419,14 @@ export class Table implements UserTable {
     this.totalHeight = height + this.headerHeight;
   }
 
-  public refresh(keepAddressCache = true, resize = false): Table {
+  public refresh(relocate = false, resize = false): Table {
     this.incrementVersion();
     this.lastChangedAt = this.changedAt;
     this.changedAt = new Date();
 
     this.clearSolvedCaches();
 
-    if (!keepAddressCache) {
+    if (relocate) {
       // force reset
       this.addressCaches.clear();
     }
@@ -436,9 +436,9 @@ export class Table implements UserTable {
     return this;
   }
 
-  public clone(keepAddressCache = true): Table {
+  public clone(relocate = false): Table {
     const copied: Table = Object.assign(Object.create(Object.getPrototypeOf(this)), this);
-    return copied.refresh(keepAddressCache);
+    return copied.refresh(relocate);
   }
 
   public getPointById(
@@ -1005,7 +1005,7 @@ export class Table implements UserTable {
       this.wire.onEdit({ table: this.__raw__.trim(dst) });
     }
 
-    return this.refresh(false);
+    return this.refresh(true);
   }
 
   public copy({
@@ -1220,7 +1220,7 @@ export class Table implements UserTable {
         partial,
       });
     }
-    return this.refresh(true, resized);
+    return this.refresh(false, resized);
   }
 
   public writeRawCellMatrix({
@@ -1394,7 +1394,7 @@ export class Table implements UserTable {
       cloned.addressCaches = new Map();
       this.wire.onInsertRows({ table: cloned, y, numRows });
     }
-    return this.refresh(false, true);
+    return this.refresh(true, true);
   }
   public removeRows({
     y,
@@ -1467,7 +1467,7 @@ export class Table implements UserTable {
       cloned.addressCaches = new Map();
       this.wire.onRemoveRows({ table: cloned, ys: ys.reverse() });
     }
-    return this.refresh(false, true);
+    return this.refresh(true, true);
   }
 
   public insertCols({
@@ -1547,7 +1547,7 @@ export class Table implements UserTable {
       cloned.addressCaches = new Map();
       this.wire.onInsertCols({ table: cloned, x, numCols });
     }
-    return this.refresh(false, true);
+    return this.refresh(true, true);
   }
   public removeCols({
     x,
@@ -1624,7 +1624,7 @@ export class Table implements UserTable {
       cloned.addressCaches = new Map();
       this.wire.onRemoveCols({ table: cloned, xs: xs.reverse() });
     }
-    return this.refresh(false, true);
+    return this.refresh(true, true);
   }
   public getHistories() {
     return [...this.wire.histories];
@@ -1804,7 +1804,7 @@ export class Table implements UserTable {
         break;
       }
     }
-    this.refresh(!shouldTracking(history.operation), true);
+    this.refresh(shouldTracking(history.operation), true);
     return {
       history,
       callback: ({ tableReactive: tableRef }: StoreType) => {
@@ -1879,7 +1879,7 @@ export class Table implements UserTable {
         }
       }
     }
-    this.refresh(!shouldTracking(history.operation), true);
+    this.refresh(shouldTracking(history.operation), true);
     return {
       history,
       callback: ({ tableReactive: tableRef }: StoreType) => {

--- a/packages/react-core/src/lib/table.ts
+++ b/packages/react-core/src/lib/table.ts
@@ -187,6 +187,8 @@ export class Table implements UserTable {
   public status: 0 | 1 | 2 = 0; // 0: not initialized, 1: initialized, 2: formula absoluted
   public wire: Wire;
   public idsToBeIdentified: Id[] = [];
+  public totalWidth = 0;
+  public totalHeight = 0;
 
   private version = 0;
   private idMatrix: IdMatrix;
@@ -405,7 +407,7 @@ export class Table implements UserTable {
     return { width, height };
   }
 
-  public getTotalSize() {
+  public setTotalSize() {
     const { bottom, right } = this.area;
     const { width, height } = this.getRectSize({
       top: 1,
@@ -413,13 +415,11 @@ export class Table implements UserTable {
       bottom: bottom + 1,
       right: right + 1,
     });
-    return {
-      totalWidth: width + this.headerWidth,
-      totalHeight: height + this.headerHeight,
-    };
+    this.totalWidth = width + this.headerWidth;
+    this.totalHeight = height + this.headerHeight;
   }
 
-  public refresh(keepAddressCache = true): Table {
+  public refresh(keepAddressCache = true, resize = false): Table {
     this.incrementVersion();
     this.lastChangedAt = this.changedAt;
     this.changedAt = new Date();
@@ -429,6 +429,9 @@ export class Table implements UserTable {
     if (!keepAddressCache) {
       // force reset
       this.addressCaches.clear();
+    }
+    if (resize) {
+      this.setTotalSize();
     }
     return this;
   }
@@ -1101,14 +1104,16 @@ export class Table implements UserTable {
     const diffAfter: CellsByIdType = {};
     const changedAt = new Date();
 
+    let resized = false;
     Object.keys(diff).forEach((address) => {
       const point = a2p(address);
       const id = this.getId(point);
       const original = this.wire.data[id]!;
-      let patch: Record<string, any> = { ...diff[address] };
       if (operator === 'USER' && operation.hasOperation(original.prevention, operation.Update)) {
         return;
       }
+
+      let patch: Record<string, any> = { ...diff[address] };
 
       if (formulaIdentify) {
         patch.value = identifyFormula(patch.value, {
@@ -1139,6 +1144,9 @@ export class Table implements UserTable {
       if (updateChangedAt) {
         this.setChangedAt(patch, changedAt);
       }
+      if (patch.width != null || patch.height != null) {
+        resized = true;
+      }
       // must not partial
       diffBefore[id] = { ...original };
 
@@ -1168,6 +1176,7 @@ export class Table implements UserTable {
     return {
       diffBefore,
       diffAfter,
+      resized,
     };
   }
 
@@ -1190,7 +1199,7 @@ export class Table implements UserTable {
     undoReflection?: StorePatchType;
     redoReflection?: StorePatchType;
   }) {
-    const { diffBefore, diffAfter } = this._update({
+    const { diffBefore, diffAfter, resized } = this._update({
       diff,
       partial,
       operator,
@@ -1211,7 +1220,7 @@ export class Table implements UserTable {
         partial,
       });
     }
-    return this.refresh(true);
+    return this.refresh(true, resized);
   }
 
   public writeRawCellMatrix({
@@ -1385,8 +1394,7 @@ export class Table implements UserTable {
       cloned.addressCaches = new Map();
       this.wire.onInsertRows({ table: cloned, y, numRows });
     }
-
-    return this.refresh(false);
+    return this.refresh(false, true);
   }
   public removeRows({
     y,
@@ -1459,8 +1467,7 @@ export class Table implements UserTable {
       cloned.addressCaches = new Map();
       this.wire.onRemoveRows({ table: cloned, ys: ys.reverse() });
     }
-
-    return this.refresh(false);
+    return this.refresh(false, true);
   }
 
   public insertCols({
@@ -1540,7 +1547,7 @@ export class Table implements UserTable {
       cloned.addressCaches = new Map();
       this.wire.onInsertCols({ table: cloned, x, numCols });
     }
-    return this.refresh(false);
+    return this.refresh(false, true);
   }
   public removeCols({
     x,
@@ -1617,7 +1624,7 @@ export class Table implements UserTable {
       cloned.addressCaches = new Map();
       this.wire.onRemoveCols({ table: cloned, xs: xs.reverse() });
     }
-    return this.refresh(false);
+    return this.refresh(false, true);
   }
   public getHistories() {
     return [...this.wire.histories];
@@ -1797,7 +1804,7 @@ export class Table implements UserTable {
         break;
       }
     }
-    this.refresh(!shouldTracking(history.operation));
+    this.refresh(!shouldTracking(history.operation), true);
     return {
       history,
       callback: ({ tableReactive: tableRef }: StoreType) => {
@@ -1872,7 +1879,7 @@ export class Table implements UserTable {
         }
       }
     }
-    this.refresh(!shouldTracking(history.operation));
+    this.refresh(!shouldTracking(history.operation), true);
     return {
       history,
       callback: ({ tableReactive: tableRef }: StoreType) => {

--- a/packages/react-core/src/store/actions.ts
+++ b/packages/react-core/src/store/actions.ts
@@ -893,7 +893,6 @@ class InsertRowsAboveAction<T extends { numRows: number; y: number; operator?: O
     });
     return {
       ...store,
-      ...table.getTotalSize(),
       tableReactive: { current: table },
     };
   }
@@ -933,7 +932,6 @@ class InsertRowsBelowAction<T extends { numRows: number; y: number; operator?: O
     });
     return {
       ...store,
-      ...table.getTotalSize(),
       selectingZone: nextSelectingZone,
       choosing: nextChoosing,
       tableReactive: { current: table },
@@ -969,7 +967,6 @@ class InsertColsLeftAction<T extends { numCols: number; x: number; operator?: Op
     });
     return {
       ...store,
-      ...table.getTotalSize(),
       tableReactive: { current: table },
     };
   }
@@ -1012,7 +1009,6 @@ class InsertColsRightAction<T extends { numCols: number; x: number; operator?: O
     });
     return {
       ...store,
-      ...table.getTotalSize(),
       selectingZone: nextSelectingZone,
       choosing: nextChoosing,
       tableReactive: { current: table },
@@ -1049,7 +1045,6 @@ class RemoveRowsAction<T extends { numRows: number; y: number; operator?: Operat
 
     return {
       ...store,
-      ...table.getTotalSize(),
       tableReactive: { current: table },
     };
   }
@@ -1084,7 +1079,6 @@ class RemoveColsAction<T extends { numCols: number; x: number; operator?: Operat
 
     return {
       ...store,
-      ...table.getTotalSize(),
       tableReactive: { current: table },
     };
   }

--- a/packages/react-core/src/types.ts
+++ b/packages/react-core/src/types.ts
@@ -135,8 +135,6 @@ export type StoreType = {
   contextMenuItems: FC<ContextMenuProps>[];
   resizingPositionY: [Y, Y, Y]; // indexY, startY, endY
   resizingPositionX: [X, X, X]; // indexX, startX, endX
-  totalWidth: number;
-  totalHeight: number;
 };
 
 export type Manager<T> = {


### PR DESCRIPTION
### Description
To resolve the issue where sheet orientation (rows and columns) failed to update correctly during row/column changes, the state management has been moved from the store to the table.  
This ensures that operations such as adding, removing, or swapping rows and columns keep the sheet’s orientation in sync, providing a consistent display.

## Type of Change
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change
- [ ] Reword
- [ ] The other

### Impact Area
- State management around the `table` component  
- Components or hooks handling row/column addition, removal, or swapping  
- Logic involved in sheet display and orientation synchronization  

## How Has This Been Tested?
You can run the following commands to verify the changes:
- [x] Visual operation check - `pnpm storybook`
- [x] Test - `pnpm test`
- [x] Lint - `pnpm lint:fix`

## Additional Context
- Previously, sheet orientation updates were managed via the store, which sometimes failed when rows or columns were altered.  
- Moving this responsibility to the table ensures that any change in row or column structure keeps the sheet orientation up-to-date.
